### PR TITLE
Updated README to add Expo config build info

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ _or_
 
 Run it in [Expo Go](https://expo.dev/expo-go) yourself!
 
+** You need to first configure ``app.json``, more specifically to change the ``"owner"`` to your Expo Go account username.
+
 ## ✨ Features
 
 ### 1. 🆕 Create your custom decks of flashcards


### PR DESCRIPTION
# What's changed?
I added a sentence to README.md instructing user with the need to change ``"owner"`` username to their specific Expo Go account username.